### PR TITLE
テーブルの書き心地改善

### DIFF
--- a/src/assets/scripts/editor/markdown-editor.ts
+++ b/src/assets/scripts/editor/markdown-editor.ts
@@ -472,7 +472,16 @@ class MarkdownEditor extends Editor {
     if (d.start !== null) {
       data.push(d)
     }
-    return data
+    // テーブルの列数が同一なもののみに絞り込む
+    const filteredData: TableData[] = []
+    data.forEach((d) => {
+      const maxCellCnt = d.rows.map((r) => r.length).reduce((a, b) => Math.max(a, b))
+      const minCellCnt = d.rows.map((r) => r.length).reduce((a, b) => Math.min(a, b))
+      if (maxCellCnt === minCellCnt) {
+        filteredData.push(d)
+      }
+    })
+    return filteredData
   }
 
   setTableData(d: TableData) {

--- a/src/assets/scripts/editor/markdown-editor.ts
+++ b/src/assets/scripts/editor/markdown-editor.ts
@@ -95,6 +95,15 @@ class MarkdownEditor extends Editor {
   onPressTab(cm: CM): void {
     const pos = cm.getCursor()
     const text = cm.getLine(pos.line)
+
+    if (isTableRow(text)) {
+      const cell = this.getFocusTableCell()
+      if (cell !== null) {
+        this.focusTableCell(pos.line, cell + 1)
+      }
+      return
+    }
+
     if (cm.somethingSelected()) {
       cm.indentSelection('add')
     } else {
@@ -115,6 +124,17 @@ class MarkdownEditor extends Editor {
    * Shift + Tab のハンドラ
    */
   onPressShiftTab(cm: CM): void {
+    const pos = cm.getCursor()
+    const text = cm.getLine(pos.line)
+
+    if (isTableRow(text)) {
+      const cell = this.getFocusTableCell()
+      if (cell !== null) {
+        this.focusTableCell(pos.line, cell - 1)
+      }
+      return
+    }
+
     cm.execCommand('indentLess')
     this.optimizeList()
   }
@@ -251,6 +271,22 @@ class MarkdownEditor extends Editor {
     const table = getDefaultTable(row, column)
     this.insert(table)
     this.focusTableCell(pos.line, 1)
+  }
+
+  getFocusTableCell(): number | null {
+    const pos = this.cm.getCursor()
+    const lineText = this.getLineText(pos.line)
+    if (!isTableRow(lineText)) {
+      return null
+    }
+
+    let cnt = 0
+    for (let i = 0; i < pos.ch; i++) {
+      if (lineText[i] === '|') {
+        cnt++
+      }
+    }
+    return cnt
   }
 
   /**

--- a/src/assets/scripts/editor/markdown-editor.ts
+++ b/src/assets/scripts/editor/markdown-editor.ts
@@ -303,7 +303,9 @@ class MarkdownEditor extends Editor {
       if (lineText[i] === '|') {
         cnt++
         if (cnt === cell) {
-          this.cm.setCursor({ line: line, ch: i + 2 })
+          const startCh = i + 2
+          const textLength = lineText.split('|')[cell].trim().length
+          this.cm.setCursor({ line: line, ch: startCh + textLength })
           return
         }
       }
@@ -430,6 +432,8 @@ class MarkdownEditor extends Editor {
   }
 
   optimizeTable(): void {
+    const pos = this.cm.getCursor()
+    const cell = this.getFocusTableCell()
     const tableData = this.getTableData()
     tableData.forEach((d: TableData) => {
       const rows = d.rows
@@ -461,6 +465,9 @@ class MarkdownEditor extends Editor {
         this.setLineText(d.start + i, text)
       })
     })
+    if (cell !== null) {
+      this.focusTableCell(pos.line, cell)
+    }
   }
 
   optimizeList(): void {

--- a/src/assets/scripts/editor/markdown-editor.ts
+++ b/src/assets/scripts/editor/markdown-editor.ts
@@ -247,8 +247,31 @@ class MarkdownEditor extends Editor {
    * テーブルを挿入します。
    */
   insertTable(row = 3, column = 3): void {
+    const pos = this.cm.getCursor()
     const table = getDefaultTable(row, column)
     this.insert(table)
+    this.focusTableCell(pos.line, 1)
+  }
+
+  /**
+   * 該当セルにフォーカスを移動します。
+   */
+  focusTableCell(line: number, cell: number): void {
+    const lineText = this.getLineText(line)
+    if (!isTableRow(lineText)) {
+      return
+    }
+
+    let cnt = 0
+    for (let i = 0; i < lineText.length; i++) {
+      if (lineText[i] === '|') {
+        cnt++
+        if (cnt === cell) {
+          this.cm.setCursor({ line: line, ch: i + 2 })
+          return
+        }
+      }
+    }
   }
 
   /**

--- a/src/components/dialog/image-dialog.vue
+++ b/src/components/dialog/image-dialog.vue
@@ -16,8 +16,8 @@
       </el-form-item>
     </el-form>
     <span slot="footer" class="dialog-footer">
-      <el-button type="primary" @click="insertImage"> Insert </el-button>
-      <el-button @click="closeDialog"> Cancel </el-button>
+      <el-button @click="closeDialog">Cancel</el-button>
+      <el-button type="primary" @click="insertImage">Insert</el-button>
     </span>
   </el-dialog>
 </template>

--- a/src/components/dialog/link-dialog.vue
+++ b/src/components/dialog/link-dialog.vue
@@ -21,8 +21,8 @@
       </el-form-item>
     </el-form>
     <span slot="footer" class="dialog-footer">
-      <el-button type="primary" @click="insertLink"> Insert </el-button>
-      <el-button @click="closeDialog"> Cancel </el-button>
+      <el-button @click="closeDialog">Cancel</el-button>
+      <el-button type="primary" @click="insertLink">Insert</el-button>
     </span>
   </el-dialog>
 </template>

--- a/src/components/dialog/rename-dialog.vue
+++ b/src/components/dialog/rename-dialog.vue
@@ -11,8 +11,8 @@
       <template slot="append"> .md </template>
     </el-input>
     <span slot="footer" class="dialog-footer">
-      <el-button type="primary" :disabled="isDisabledChange" @click="changeFileName"> Change </el-button>
-      <el-button @click="closeDialog"> Cancel </el-button>
+      <el-button @click="closeDialog">Cancel</el-button>
+      <el-button type="primary" :disabled="isDisabledChange" @click="changeFileName">Change</el-button>
     </span>
   </el-dialog>
 </template>

--- a/src/components/dialog/table-dialog.vue
+++ b/src/components/dialog/table-dialog.vue
@@ -16,8 +16,8 @@
       </el-form-item>
     </el-form>
     <span slot="footer" class="dialog-footer">
-      <el-button type="primary" @click="insertTable"> Insert </el-button>
-      <el-button @click="closeDialog"> Cancel </el-button>
+      <el-button @click="closeDialog">Cancel</el-button>
+      <el-button type="primary" @click="insertTable">Insert</el-button>
     </span>
   </el-dialog>
 </template>

--- a/src/components/editor.vue
+++ b/src/components/editor.vue
@@ -135,7 +135,7 @@ export default Vue.extend({
       const pos = cm.getCursor()
       const lineText = this.editor?.getLineText(pos.line)
       if (lineText && isTableRow(lineText)) {
-        // 英数・かな入力、BS、ペースト時のみテーブル最適化
+        // 英数・かな入力（スペース除く）、BS、ペースト時のみテーブル最適化
         if (
           (['+input', '*compose'].includes(event.origin) && event.text[0].trim().length > 0) ||
           ['+delete', 'paste'].includes(event.origin)

--- a/src/components/editor.vue
+++ b/src/components/editor.vue
@@ -12,7 +12,7 @@ import { ipcRenderer } from 'electron'
 import { Editor as CM } from 'codemirror'
 import MarkdownEditor from '@/assets/scripts/editor/markdown-editor'
 import { VIEW_MODE, ALLOW_DROP_FILE_TYPES } from '@/constants'
-import { isCodeBlock, getDefaultCodeBlock } from '@/utils/markdown'
+import { isCodeBlock, getDefaultCodeBlock, isTableRow } from '@/utils/markdown'
 import 'codemirror/lib/codemirror.css'
 import '@/assets/styles/editor/markdown.scss'
 const API_KEY = process.env.VUE_APP_MELT_API_KEY
@@ -131,9 +131,20 @@ export default Vue.extend({
     },
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    onChangeText(editor: CM, event: any) {
+    onChangeText(cm: CM, event: any) {
+      const pos = cm.getCursor()
+      const lineText = this.editor?.getLineText(pos.line)
+      if (lineText && isTableRow(lineText)) {
+        // 英数・かな入力、BS、ペースト時のみテーブル最適化
+        if (
+          (['+input', '*compose'].includes(event.origin) && event.text[0].trim().length > 0) ||
+          ['+delete', 'paste'].includes(event.origin)
+        ) {
+          this.editor?.optimizeTable()
+        }
+      }
       if (this.isInsertCodeBlock(event)) {
-        const currentLine = editor.getCursor().line
+        const currentLine = cm.getCursor().line
         this.editor?.selectLine(currentLine)
         this.editor?.insertText(getDefaultCodeBlock())
         this.editor?.gotoLine(currentLine + 1)
@@ -142,7 +153,7 @@ export default Vue.extend({
     },
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    onPasteText(editor: CM, event: any) {
+    onPasteText(cm: CM, event: any) {
       if (this.isPasteAsPlainText) {
         return
       }
@@ -172,7 +183,7 @@ export default Vue.extend({
     },
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    onDropFile(editor: CM, event: any) {
+    onDropFile(cm: CM, event: any) {
       const files = event.dataTransfer.files
       if (files.length > 1) {
         return


### PR DESCRIPTION
- テーブル新規作成時の、初期カーソル位置を左上のセルにする
- 「tab」 で 右の column に移動
- 「shift + tab」 で左の column に移動
- テーブル幅調整後のカーソル位置を元の状態を維持するように修正
- 文字入力と同時にテーブル幅の自動調整
- 「|」が全角文字があると縦ずれする事象の修正
- 最終 column の 「tab」 で 新しく column 挿入
- row の末尾 Enter で row 挿入